### PR TITLE
Automatically generate OAuth flow URI. Fixes #1.

### DIFF
--- a/php/WcaOauth.php
+++ b/php/WcaOauth.php
@@ -3,11 +3,13 @@
 class WcaOauth
 {
     CONST ACCESS_TOKEN_URI = "https://www.worldcubeassociation.org/oauth/token";
+    CONST OAUTH_AUTHORIZE_URI = "https://www.worldcubeassociation.org/oauth/authorize";
     CONST USER_URI = "https://www.worldcubeassociation.org/api/v0/me";
 
     protected $applicationId;
-    protected $redirectUri;
     protected $applicationSecret;
+    protected $redirectUri;
+    protected $scope;
 
     protected static $requiredOptions = array(
         'applicationId',
@@ -19,12 +21,27 @@ class WcaOauth
 
     public function __construct($options)
     {
+        $this->setOptions($options);
+        $this->checkRequiredOptionsSet();
+    }
+
+    protected function checkRequiredOptionsSet()
+    {
         foreach (self::$requiredOptions AS $value) {
-            if (!isset($options[$value])) {
+            if (!isset($this->$value)) {
                 throw new Exception("$value is a required option!");
             }
+        }
+    }
 
-            $this->$value = $options[$value];
+    protected function setOptions($options)
+    {
+        foreach ($options AS $key => $value) {
+            if (is_array($value)) {
+                $value = implode(' ', $value);
+            }
+
+            $this->$key = $value;
         }
     }
 
@@ -77,6 +94,18 @@ class WcaOauth
         if ($error) {
             throw new WcaOauthException($error);
         }
+    }
+
+    public function generateOauthFlowUri()
+    {
+        $params = http_build_query([
+            'client_id' => $this->applicationId,
+            'redirect_uri' => $this->redirectUri,
+            'response_type' => 'code',
+            'scope' => $this->scope,
+        ]);
+
+        return sprintf("%s?%s", self::OAUTH_AUTHORIZE_URI, $params);
     }
 
     /**

--- a/php/WcaOauth.php
+++ b/php/WcaOauth.php
@@ -22,7 +22,6 @@ class WcaOauth
     public function __construct($options)
     {
         $this->setOptions($options);
-        $this->checkRequiredOptionsSet();
     }
 
     protected function checkRequiredOptionsSet()
@@ -37,12 +36,10 @@ class WcaOauth
     protected function setOptions($options)
     {
         foreach ($options AS $key => $value) {
-            if (is_array($value)) {
-                $value = implode(' ', $value);
-            }
-
             $this->$key = $value;
         }
+
+        $this->checkRequiredOptionsSet();
     }
 
     /**
@@ -102,7 +99,7 @@ class WcaOauth
             'client_id' => $this->applicationId,
             'redirect_uri' => $this->redirectUri,
             'response_type' => 'code',
-            'scope' => $this->scope,
+            'scope' => implode(' ', $this->scope),
         ]);
 
         return sprintf("%s?%s", self::OAUTH_AUTHORIZE_URI, $params);


### PR DESCRIPTION
I needed to change how the constructor set the options iin order to allow for
optional options (that seems a bit redundant). I extracted the setting of the
options into a method, and check required options, just to clean up the
constructor. Also, out of OCD, I moved the redirectUri variable so that the
application id and secret were next to each other, and this alphabetizes things
nicely :)
